### PR TITLE
Add deps.edn support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+tmp/
+target/
+.cpcache/
+
+

--- a/README.md
+++ b/README.md
@@ -8,3 +8,10 @@ Desktop EPUB reader written in Clojure.
 
 
     $ lein run
+
+# Running with clj
+
+```bash
+clj -Sdeps '{:deps {epub {:git/url "https://github.com/netb258/clj-pub.git" :sha "<SHA>"}}}' -m epub.core
+```
+

--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ Desktop EPUB reader written in Clojure.
 # Running with clj
 
 ```bash
-clj -Sdeps '{:deps {epub {:git/url "https://github.com/netb258/clj-pub.git" :sha "<SHA>"}}}' -m epub.core
+clj -Sdeps '{:deps {epub {:git/url "https://github.com/netb258/clj-pub.git" :sha "ddb25952afbb4e7e2a58647d72e99adf95e3b65e"}}}' -m epub.core
 ```
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,5 @@
+{:deps {org.clojure/clojure {:mvn/version "1.10.1"}
+        me.raynes/fs {:mvn/version "1.4.6"}
+        net.sf.cssbox/swingbox {:mvn/version "1.1"}
+        seesaw {:mvn/version "1.5.0"}}}
+


### PR DESCRIPTION
It will allow users to try this software without clone/download

ATM it's only in my repo, so you can use/try with
`clj -Sdeps '{:deps {epub {:git/url "https://github.com/souenzzo/clj-pub.git" :sha "ddb25952afbb4e7e2a58647d72e99adf95e3b65e"}}}' -m epub.core`

Once it's merged, you will be able to use the command on `README.md`